### PR TITLE
Add script to send CanaryTest messages to datadog.

### DIFF
--- a/armory/scripts/inject_canary_errors.py
+++ b/armory/scripts/inject_canary_errors.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import time
+
+import datadog
+
+from armory.hellodeploy import kv_parser
+
+
+datadog_options = {
+    'api_key':'71120e33fa59c2bf8af09b6d881344b4',
+    'app_key':'hellodeploy'
+}
+
+datadog.initialize(**datadog_options)
+
+def main():
+    try:
+        kv_text = open('/etc/default/server-env').read()
+    except FileNotFoundError:
+        kv_text = open('etc/server-env').read()
+
+    env_kv = kv_parser.parse(kv_text)
+
+    if "CANARYERRORS" not in env_kv:
+        return
+
+    # Loop because DataDog doesn't reliably tag the events with ASG,
+    # so the monitor doesn't have that info when it alerts,
+    # and Barometer can't tell which canary to fail.
+
+    while True:
+        for _ in range(5):
+            datadog.dogstatsd.statsd.event('CanaryTest', 'canarytest: autoscaling_group:%s' % env_kv["CLOUD_SERVER_GROUP"])
+
+        print("Delivered 5 CanaryTest events to datadog.")
+        time.sleep(120)
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/armory-hello-deploy.conf
+++ b/etc/armory-hello-deploy.conf
@@ -15,5 +15,6 @@ script
     fi
 
   . /etc/default/armory-hello-deploy
+  inject_canary_errors.py &
   hello_deploy_start.py
 end script

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='hello-deploy',
     #     'armory.hellodeploy.static',
     #     'armory.hellodeploy.templates'
     # ],
-    scripts=['armory/scripts/hello_deploy_start.py'],
+    scripts=['armory/scripts/hello_deploy_start.py', 'armory/scripts/inject_canary_errors.py'],
     include_package_data=True,
     data_files=[
         ('/etc/init/',['/home/armory/etc/armory-hello-deploy.conf']),


### PR DESCRIPTION
The messages will be sent if CANARYERRORS is set in/etc/default/server-env .

This additional variable is added to the server-env file by the Canary
stage in the UserData for the Canary cluster.